### PR TITLE
Support template v2 with legacy rating parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export interface OptionsV1 extends TransformOptions {
 
 export interface OptionsV2 extends TransformV2Options {
   template: 'surveyV2';
+  legacyRatingParameterMode?: boolean;
 }
 
 export type Options = OptionsV1 | OptionsV2;

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -165,6 +165,27 @@ describe('email', function() {
       assert.equal($('a[href*="survey?token=aaa"]').length, 11);
     });
 
+    it('should handle NPS in legacy rating parameter mode', function() {
+      const html = render({
+        template: 'surveyV2',
+        legacyRatingParameterMode: true,
+        url: 'localhost/survey',
+        urlParams: { token: 'aaa' },
+        question: {
+          id: 'SM_rating',
+          label: messages.HOW_LIKELY,
+          type: 'scale',
+          max: 10,
+          min: 0,
+          maxLegend: messages.LIKELY,
+          minLegend: messages.UNLIKELY
+        }
+      });
+
+      const $ = cheerio.load(html);
+      assert.equal($('a[href*="survey?token=aaa&rating="]').length, 11);
+    });
+
     it('should handle single-choice surveys', function() {
       const html = render({
         template: 'surveyV2',

--- a/src/transformV2.ts
+++ b/src/transformV2.ts
@@ -34,6 +34,7 @@ export interface TransformV2Options {
   unsubscribeUrl?: string;
   url?: string;
   urlParams: { [key: string]: string | number | boolean | undefined };
+  legacyRatingParameterMode?: boolean;
 }
 
 const DEFAULT_COLORS = {
@@ -72,7 +73,15 @@ export function transformV2(
     }
 
     if (options.question.id) {
-      uri.addQueryParam(`answers[${options.question.id}]`, value);
+      const legacyRatingParameter =
+        options.question.id === 'SM_rating' &&
+        options.legacyRatingParameterMode;
+
+      if (legacyRatingParameter) {
+        uri.addQueryParam('rating', value);
+      } else {
+        uri.addQueryParam(`answers[${options.question.id}]`, value);
+      }
     }
 
     return uri.toString();


### PR DESCRIPTION
Currently we assume that widget is updated and can handle answers value by id. With email-surveys v2 being the first PR for custom surveys we need to be able to pass it as rating parameter