### PR TITLE
fix: Encoding answers URL parameter

### DIFF
--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -229,8 +229,8 @@ describe('email', function() {
       });
 
       const $ = cheerio.load(html);
-      assert.equal($('a[href*="survey?token=aaa&answers[QID]=abc"]').length, 1);
-      assert.equal($('a[href*="survey?token=aaa&answers[QID]=123"]').length, 1);
+      assert.equal($('a[href*="survey?token=aaa&answers%5BQID%5D=abc"]').length, 1);
+      assert.equal($('a[href*="survey?token=aaa&answers%5BQID%5D=123"]').length, 1);
     });
 
     it('should handle custom scale surveys', function() {
@@ -252,9 +252,9 @@ describe('email', function() {
       });
 
       const $ = cheerio.load(html);
-      assert.equal($('a[href*="survey?token=aaa&answers[QID]=1"]').length, 1);
-      assert.equal($('a[href*="survey?token=aaa&answers[QID]=2"]').length, 1);
-      assert.equal($('a[href*="survey?token=aaa&answers[QID]=3"]').length, 1);
+      assert.equal($('a[href*="survey?token=aaa&answers%5BQID%5D=1"]').length, 1);
+      assert.equal($('a[href*="survey?token=aaa&answers%5BQID%5D=2"]').length, 1);
+      assert.equal($('a[href*="survey?token=aaa&answers%5BQID%5D=3"]').length, 1);
     });
 
     it('should handle odd custom scales', function() {
@@ -276,9 +276,9 @@ describe('email', function() {
       });
 
       const $ = cheerio.load(html);
-      assert.equal($('a[href*="survey?token=aaa&answers[QID]=-1"]').length, 1);
-      assert.equal($('a[href*="survey?token=aaa&answers[QID]=-2"]').length, 1);
-      assert.equal($('a[href*="survey?token=aaa&answers[QID]=-3"]').length, 1);
+      assert.equal($('a[href*="survey?token=aaa&answers%5BQID%5D=-1"]').length, 1);
+      assert.equal($('a[href*="survey?token=aaa&answers%5BQID%5D=-2"]').length, 1);
+      assert.equal($('a[href*="survey?token=aaa&answers%5BQID%5D=-3"]').length, 1);
     });
 
     it('should include bot-honeypot-link', function() {

--- a/src/transformV2.ts
+++ b/src/transformV2.ts
@@ -105,7 +105,10 @@ export function transformV2(options: TransformV2Options): TemplateV2Options {
       if (legacyRatingParameter) {
         uri.addQueryParam('rating', value);
       } else {
-        uri.addQueryParam(`answers[${options.question.id}]`, value);
+        uri.addQueryParam(
+          encodeURIComponent(`answers[${options.question.id}]`),
+          value
+        );
       }
     }
 


### PR DESCRIPTION
Coming from support. https://app.intercom.com/a/apps/w3bimpuv/inbox/inbox/mentions/conversations/36000099625

That customer is using a provider with variables like `[email]`, `[fullname]`... Since the params answer is `answers[questionId]=val` the provider thinks it's a variable and tries to replace it by its value, rendering `answers=val`. A good fix is to encode the parameter.